### PR TITLE
Fetch images logic

### DIFF
--- a/Android/app/build.gradle.kts
+++ b/Android/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.fragment.ktx)
+    implementation ("org.jsoup:jsoup:1.15.4")
     implementation("androidx.navigation:navigation-fragment-ktx:2.9.0")
     implementation("androidx.navigation:navigation-ui-ktx:2.9.0")
     implementation(libs.androidx.navigation.fragment)

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/Android/app/src/main/java/iss/nus/edu/sg/memory_game/fragment/FetchFragment.kt
+++ b/Android/app/src/main/java/iss/nus/edu/sg/memory_game/fragment/FetchFragment.kt
@@ -1,8 +1,8 @@
 package iss.nus.edu.sg.memory_game.fragment
 
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.view.*
 import android.widget.*
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
@@ -12,15 +12,20 @@ import iss.nus.edu.sg.memory_game.R
 import iss.nus.edu.sg.memory_game.adapter.ImageAdapter
 import iss.nus.edu.sg.memory_game.model.ImageItem
 import kotlinx.coroutines.*
+import org.jsoup.Jsoup
 import java.io.File
 import java.io.FileOutputStream
-import android.graphics.Bitmap
+import java.net.URL
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 
 class FetchFragment : Fragment() {
 
     private val imageItems = mutableListOf<ImageItem>()
     private lateinit var imageAdapter: ImageAdapter
     private lateinit var confirmButton: Button
+    private var fetchJob: Job? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_fetch, container, false)
@@ -32,7 +37,9 @@ class FetchFragment : Fragment() {
         val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerView)
         confirmButton = view.findViewById(R.id.btnConfirm)
         val progressBar = view.findViewById<ProgressBar>(R.id.fetchProgressBar)
+        val progressText = view.findViewById<TextView>(R.id.tvProgress)
         val btnFetch = view.findViewById<Button>(R.id.btnFetch)
+        val etUrl = view.findViewById<EditText>(R.id.etUrl)
 
         confirmButton.isEnabled = false
 
@@ -44,15 +51,68 @@ class FetchFragment : Fragment() {
         recyclerView.adapter = imageAdapter
 
         btnFetch.setOnClickListener {
-            progressBar.visibility = View.VISIBLE
-            imageItems.clear()
-            val bmp = BitmapFactory.decodeResource(requireContext().resources, R.drawable.placeholder_image)
-            repeat(20) {
-                val safeConfig = bmp.config ?: Bitmap.Config.ARGB_8888
-                imageItems.add(ImageItem(bmp.copy(safeConfig, true)))
+            fetchJob?.cancel()
+
+            val urlInput = etUrl.text.toString().trim().let {
+                if (it.startsWith("http://") || it.startsWith("https://")) it else "https://$it"
             }
+
+            imageItems.clear()
             imageAdapter.notifyDataSetChanged()
-            progressBar.visibility = View.GONE
+
+            progressBar.progress = 0
+            progressBar.visibility = View.VISIBLE
+            progressText.visibility = View.VISIBLE
+            progressText.text = "Starting download…"
+
+            fetchJob = CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val doc = Jsoup.connect(urlInput)
+                        .userAgent("Mozilla")
+                        .get()
+
+                    val urls = doc.select("img[src]")
+                        .map { it.absUrl("src") }
+                        .filter { it.endsWith(".jpg") || it.endsWith(".jpeg") || it.endsWith(".png") }
+                        .take(20)
+
+                    withContext(Dispatchers.Main) {
+                        progressBar.max = urls.size
+                    }
+
+                    urls.forEachIndexed { index, imageUrl ->
+                        try {
+                            val connection = URL(imageUrl).openConnection().apply {
+                                setRequestProperty("User-Agent", "Mozilla")
+                            }
+                            connection.getInputStream().use { input ->
+                                val bmp = BitmapFactory.decodeStream(input)
+                                if (bmp != null) {
+                                    withContext(Dispatchers.Main) {
+                                        val config = bmp.config ?: Bitmap.Config.ARGB_8888
+                                        imageItems.add(ImageItem(bmp.copy(config, true)))
+                                        imageAdapter.notifyItemInserted(imageItems.size - 1)
+                                        progressBar.progress = index + 1
+                                        progressText.text = "Downloading ${index + 1} of ${urls.size} images…"
+                                    }
+                                }
+                            }
+                        } catch (_: Exception) {
+                            // silently skip
+                        }
+                    }
+
+                } catch (e: Exception) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(requireContext(), "Failed to fetch images.", Toast.LENGTH_LONG).show()
+                    }
+                } finally {
+                    withContext(Dispatchers.Main) {
+                        progressBar.visibility = View.GONE
+                        progressText.visibility = View.GONE
+                    }
+                }
+            }
         }
 
         confirmButton.setOnClickListener {
@@ -63,10 +123,10 @@ class FetchFragment : Fragment() {
             }
 
             CoroutineScope(Dispatchers.IO).launch {
-                selected.forEachIndexed { index, imageItem ->
+                selected.forEachIndexed { index, item ->
                     val file = File(requireContext().cacheDir, "image_${index + 1}.jpg")
                     FileOutputStream(file).use {
-                        imageItem.bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
+                        item.bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
                     }
                 }
                 withContext(Dispatchers.Main) {

--- a/Android/app/src/main/res/layout/fragment_fetch.xml
+++ b/Android/app/src/main/res/layout/fragment_fetch.xml
@@ -6,7 +6,6 @@
     android:layout_height="match_parent"
     android:padding="24dp">
 
-    <!-- Existing UI (title, URL, fetch button, etc.) -->
     <TextView
         android:id="@+id/tvFetchTitle"
         android:layout_width="wrap_content"
@@ -20,9 +19,9 @@
 
     <TextView
         android:id="@+id/tvFetchDesc"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Enter the URL to fetch your data before playing."
+        android:text="Enter a URL to fetch pictures for gameplay!"
         android:textSize="16sp"
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/tvFetchTitle"
@@ -33,7 +32,8 @@
         android:id="@+id/etUrl"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:hint="Enter URL here"
+        android:hint="Enter website (e.g. example.com)"
+        android:textSize="15sp"
         android:inputType="textUri"
         android:layout_marginTop="16dp"
         app:layout_constraintTop_toBottomOf="@id/tvFetchDesc"
@@ -51,20 +51,24 @@
 
     <ProgressBar
         android:id="@+id/fetchProgressBar"
-        android:layout_width="wrap_content"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         android:layout_marginTop="32dp"
+        android:indeterminate="false"
+        android:max="20"
+        android:progress="0"
+        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/btnFetch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <ImageView
-        android:id="@+id/imgFetch"
-        android:layout_width="180dp"
-        android:layout_height="180dp"
-        android:layout_marginTop="24dp"
-        android:src="@drawable/ic_launcher_foreground"
+    <TextView
+        android:id="@+id/tvProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/fetchProgressBar"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -72,9 +76,10 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"
-        android:layout_height="200dp"
+        android:layout_height="0dp"
         android:layout_marginTop="24dp"
-        app:layout_constraintTop_toBottomOf="@id/imgFetch"
+        app:layout_constraintTop_toBottomOf="@id/tvProgress"
+        app:layout_constraintBottom_toTopOf="@id/btnConfirm"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -86,15 +91,6 @@
         android:enabled="false"
         android:layout_marginTop="16dp"
         app:layout_constraintTop_toBottomOf="@id/recyclerView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <Button
-        android:id="@+id/btnToPlay"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="Go to Play"
-        android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
- replaced url field default text with hint: "enter website (e.g. www.example.com)"

- implemented image scraping using jsoup and bitmap decoding, 20 pics

- added progress bar (horizontal) with download count updates

- allowed fetch restart with new url by canceling ongoing job

- navigated to play activity button removed, as "Confirm" button serve the same purpose.

- adjusted hint text size for better ui